### PR TITLE
feat(forge): adopt shared skin runtime

### DIFF
--- a/apps/forge-desktop/src/App.tsx
+++ b/apps/forge-desktop/src/App.tsx
@@ -8,6 +8,8 @@ const desktopShell: ForgeShellConfig = {
     workspaceName: 'loop-kit',
     environmentLabel: 'Tauri desktop shell',
     navigationMode: 'hash',
+    skinId: 'forge',
+    skinMode: 'dark',
     capabilitySummary: [
         'Tauri v2 native shell around the shared Forge frontend package',
         'Hash-safe route handling for local desktop bootstrapping',

--- a/apps/forge-web/src/App.tsx
+++ b/apps/forge-web/src/App.tsx
@@ -8,6 +8,8 @@ const webShell: ForgeShellConfig = {
     workspaceName: 'loop-kit',
     environmentLabel: 'Vite web shell',
     navigationMode: 'history',
+    skinId: 'forge',
+    skinMode: 'dark',
     capabilitySummary: [
         'Browser-native deep links for shell routes',
         'Preview-deploy friendly static build output',

--- a/packages/forge-app/src/forge-app.tsx
+++ b/packages/forge-app/src/forge-app.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Panel, ThemeProvider, cn, defaultThemeSet } from '@loop-kit/ui';
+import { Panel, UiProvider, cn, resolveDefaultUiSkin } from '@loop-kit/ui';
 
 import { useForgeNavigation } from './navigation';
 import { forgeRoutes, resolveForgeHref } from './routes';
@@ -235,9 +235,11 @@ function ShellHeader({
 export function ForgeApp({ shell, initialPath = '/' }: ForgeAppProps) {
     const mode = shell.navigationMode ?? 'history';
     const { route, navigate } = useForgeNavigation(mode, initialPath);
+    const skin = resolveDefaultUiSkin(shell.skinId);
+    const skinMode = shell.skinMode ?? 'dark';
 
     return (
-        <ThemeProvider theme={defaultThemeSet} mode='dark'>
+        <UiProvider skin={skin} mode={skinMode}>
             <div className='min-h-screen'>
                 <div className='mx-auto flex min-h-screen w-full max-w-[1760px] gap-4 p-4 md:p-6'>
                     <ShellAside shell={shell} activeRoute={route} onNavigate={navigate} />
@@ -248,6 +250,6 @@ export function ForgeApp({ shell, initialPath = '/' }: ForgeAppProps) {
                     </main>
                 </div>
             </div>
-        </ThemeProvider>
+        </UiProvider>
     );
 }

--- a/packages/forge-app/src/types.ts
+++ b/packages/forge-app/src/types.ts
@@ -1,3 +1,5 @@
+import type { ThemeMode } from '@loop-kit/ui';
+
 export type ForgeRouteId =
     | 'home'
     | 'workspace'
@@ -25,6 +27,8 @@ export type ForgeShellConfig = {
     workspaceName: string;
     environmentLabel: string;
     navigationMode?: ForgeNavigationMode;
+    skinId?: string;
+    skinMode?: ThemeMode;
     capabilitySummary?: readonly string[];
     notes?: readonly string[];
 };


### PR DESCRIPTION
## Purpose
Make Forge consume the shared UI skin runtime instead of keeping a direct `defaultThemeSet` fork path inside the shell package.

## Scope
- replace Forge's `ThemeProvider/defaultThemeSet` usage with `UiProvider` and the shared default skin selection path
- add shell-level `skinId` and `skinMode` config so web and desktop shells can choose skins without forking theme logic
- keep Forge routes and panel-host behavior static otherwise

## Risks
- Forge shell config shape changes slightly with the new optional skin fields
- visual regressions would affect both web and desktop shells because they now share the exact same skin runtime path

## Linked Issues
- closes #36
- part of #30

## Rollout / Feature Flags
- no feature flag; this is shared shell infrastructure only
- the next product-facing work moves to #33, #34, #38, and #39

## Dependency Notes
- `#32` was closed separately after auditing the merged skin runtime work
- `#38`, `#39`, and `#40` were created to keep the next Forge/product and extension slices separate